### PR TITLE
Fix bingo info permission error for all users

### DIFF
--- a/src/hooks/useGameManagement.ts
+++ b/src/hooks/useGameManagement.ts
@@ -14,10 +14,8 @@ import { api } from "~/utils/api";
  */
 export const useGameManagement = (gameId: string) => {
   // ゲーム情報の取得
-  const { data: bingoGame, refetch: refetchGame } = api.bingo.getById.useQuery(
-    { id: gameId },
-    { enabled: !!gameId }
-  );
+  const { data: bingoGame, refetch: refetchGame } =
+    api.bingo.getByIdForAdmin.useQuery({ id: gameId }, { enabled: !!gameId });
 
   // 参加者一覧の取得
   const { data: participants, refetch: refetchParticipants } =

--- a/src/pages/admin/game/[id]/qr.tsx
+++ b/src/pages/admin/game/[id]/qr.tsx
@@ -14,7 +14,7 @@ const QRCodePrintPage: NextPage = () => {
   const [qrCodeDataUrl, setQrCodeDataUrl] = useState<string>("");
   const [participantUrl, setParticipantUrl] = useState<string>("");
 
-  const { data: bingoGame } = api.bingo.getById.useQuery(
+  const { data: bingoGame } = api.bingo.getByIdForAdmin.useQuery(
     { id: id as string },
     { enabled: !!id && !!session }
   );

--- a/src/server/api/routers/bingo.ts
+++ b/src/server/api/routers/bingo.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
-import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { createTRPCRouter, protectedProcedure, publicProcedure } from "~/server/api/trpc";
 import {
   getGridSize,
   getRequiredSongCount,
@@ -292,24 +292,10 @@ export const bingoRouter = createTRPCRouter({
       };
     }),
 
-  getById: protectedProcedure
+  getById: publicProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
-      // Check if current user has admin permission
-      const hasPermission = await checkGameAdminPermission(
-        ctx.repositories,
-        input.id,
-        ctx.session.user.id
-      );
-
-      if (!hasPermission) {
-        throw new TRPCError({
-          code: "FORBIDDEN",
-          message: "このゲームにアクセスする権限がありません",
-        });
-      }
-
-      const bingoGame = await ctx.repositories.bingoGame.findByIdWithDetails(
+      const bingoGame = await ctx.repositories.bingoGame.findByIdWithSongs(
         input.id
       );
 


### PR DESCRIPTION
bingo.getByIdをprotectedProcedureからpublicProcedureに変更し、 参加者も認証なしでビンゴゲームの基本情報を取得できるようにした。
管理者権限チェックを削除し、findByIdWithDetailsではなく
findByIdWithSongsを使用することで、必要最小限の情報のみを公開。