### PR TITLE
fix: Chromatic CI の build-storybook 失敗を修正

### DIFF
--- a/src/components/admin/ParticipantTable.stories.tsx
+++ b/src/components/admin/ParticipantTable.stories.tsx
@@ -60,6 +60,7 @@ const manyParticipants: Participant[] = Array.from({ length: 20 }, (_, i) =>
 export const Default: Story = {
   args: {
     participants,
+    songs: [],
     sortField: "createdAt",
     sortDirection: "desc",
     onSort: () => {},
@@ -69,6 +70,7 @@ export const Default: Story = {
 export const Empty: Story = {
   args: {
     participants: [],
+    songs: [],
     sortField: "createdAt",
     sortDirection: "desc",
     onSort: () => {},
@@ -78,6 +80,7 @@ export const Empty: Story = {
 export const ManyParticipants: Story = {
   args: {
     participants: manyParticipants,
+    songs: [],
     sortField: "createdAt",
     sortDirection: "desc",
     onSort: () => {},
@@ -87,6 +90,7 @@ export const ManyParticipants: Story = {
 export const AllWinners: Story = {
   args: {
     participants: participants.map((p) => ({ ...p, hasWon: true })),
+    songs: [],
     sortField: "createdAt",
     sortDirection: "desc",
     onSort: () => {},
@@ -96,6 +100,7 @@ export const AllWinners: Story = {
 export const AllIncomplete: Story = {
   args: {
     participants: participants.map((p) => ({ ...p, isGridComplete: false })),
+    songs: [],
     sortField: "createdAt",
     sortDirection: "desc",
     onSort: () => {},
@@ -103,7 +108,13 @@ export const AllIncomplete: Story = {
 };
 
 export const Interactive: Story = {
-  args: {},
+  args: {
+    participants,
+    songs: [],
+    sortField: "createdAt",
+    sortDirection: "desc",
+    onSort: () => {},
+  },
   render: () => {
     const { sortField, sortDirection, handleSort, sortParticipants } =
       useParticipantSort();
@@ -112,6 +123,7 @@ export const Interactive: Story = {
     return (
       <ParticipantTable
         participants={sorted}
+        songs={[]}
         sortField={sortField}
         sortDirection={sortDirection}
         onSort={handleSort}

--- a/src/components/bingo/BingoGrid.stories.tsx
+++ b/src/components/bingo/BingoGrid.stories.tsx
@@ -154,7 +154,10 @@ export const Interactive: Story = {
 };
 
 export const AllSizes: Story = {
-  args: {},
+  args: {
+    grid: partialGrid3x3,
+    gridSize: 3,
+  },
   render: () => (
     <div className="flex flex-col gap-8">
       <div>

--- a/src/components/bingo/WinStatus.stories.tsx
+++ b/src/components/bingo/WinStatus.stories.tsx
@@ -84,7 +84,11 @@ export const RecentWin: Story = {
 };
 
 export const States: Story = {
-  args: {},
+  args: {
+    hasWon: false,
+    grid: noWinGrid,
+    gridSize: 3,
+  },
   render: () => (
     <div className="flex flex-col gap-8">
       <div>

--- a/src/components/bingo/WinnerBanner.stories.tsx
+++ b/src/components/bingo/WinnerBanner.stories.tsx
@@ -31,7 +31,9 @@ export const NotWon: Story = {
 };
 
 export const Comparison: Story = {
-  args: {},
+  args: {
+    hasWon: false,
+  },
   render: () => (
     <div className="space-y-4">
       <div>

--- a/src/components/common/SongInfo.stories.tsx
+++ b/src/components/common/SongInfo.stories.tsx
@@ -60,7 +60,9 @@ export const CustomClassName: Story = {
 };
 
 export const Examples: Story = {
-  args: {},
+  args: {
+    title: "",
+  },
   render: () => (
     <div className="flex w-96 flex-col gap-4">
       <div className="rounded-lg border border-gray-200 p-3">

--- a/src/components/ui/Button.stories.tsx
+++ b/src/components/ui/Button.stories.tsx
@@ -84,7 +84,9 @@ export const Gray: Story = {
 };
 
 export const AllVariants: Story = {
-  args: {},
+  args: {
+    children: "Button",
+  },
   render: () => (
     <div className="flex flex-col gap-4">
       <div className="flex gap-2">

--- a/src/components/ui/SearchInput.stories.tsx
+++ b/src/components/ui/SearchInput.stories.tsx
@@ -49,23 +49,32 @@ const SearchInputWithState = (args: {
   );
 };
 
+const baseArgs = {
+  value: "",
+  onChange: () => {},
+};
+
 export const Default: Story = {
+  args: baseArgs,
   render: () => <SearchInputWithState />,
 };
 
 export const WithPlaceholder: Story = {
+  args: baseArgs,
   render: () => (
     <SearchInputWithState placeholder="楽曲名またはアーティスト名で検索..." />
   ),
 };
 
 export const BlueFocus: Story = {
+  args: baseArgs,
   render: () => (
     <SearchInputWithState placeholder="Blue focus color..." focusColor="blue" />
   ),
 };
 
 export const GreenFocus: Story = {
+  args: baseArgs,
   render: () => (
     <SearchInputWithState
       placeholder="Green focus color..."
@@ -75,6 +84,7 @@ export const GreenFocus: Story = {
 };
 
 export const WithResultCount: Story = {
+  args: baseArgs,
   render: () => (
     <SearchInputWithState
       placeholder="Search with result count..."
@@ -85,6 +95,7 @@ export const WithResultCount: Story = {
 };
 
 export const AllVariants: Story = {
+  args: baseArgs,
   render: () => (
     <div className="flex flex-col gap-6 p-4">
       <div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,5 +34,5 @@
     "**/*.js",
     ".next/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "**/*.stories.tsx"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 概要

Chromatic CI が直近 10 回連続で失敗していた問題を修正する。

Storybook v10.0.2 → v10.3.6 のアップデートで `@storybook/nextjs-vite` が tsconfig の `include`/`exclude` を厳密に尊重するようになり、`*.stories.tsx` を `exclude` に入れていたために `~/*` の path alias が解決できず、`build-storybook` が下記エラーで失敗するようになっていた。

```
[vite]: Rollup failed to resolve import "~/hooks/useParticipantSort"
from "./src/components/admin/ParticipantTable.stories.tsx"
```

## 変更内容

- `tsconfig.json` の `exclude` から `**/*.stories.tsx` を削除し、Storybook の path alias 解決を復活させた(root cause)
- 副作用として stories が型検査対象に戻り、props 不足などの蓄積していた型エラーが顕在化したため、以下の stories を修正
  - `ParticipantTable.stories.tsx`: 必須 prop の `songs` を全 story に追加、`Interactive` の args を補完
  - `BingoGrid.stories.tsx` / `WinStatus.stories.tsx` / `WinnerBanner.stories.tsx` / `SongInfo.stories.tsx` / `Button.stories.tsx`: `args: {}` で必須 props が欠けていた story に最低限の args を補完
  - `SearchInput.stories.tsx`: `render` のみで `args` が欠けていた全 story に `args: { value, onChange }` を追加

## 動作確認

ローカルで Storybook v10.3.6 を `npm install` した上で CI 同等の環境で実行し、すべてグリーンであることを確認した。

- `npm run type-check`: ✅ pass
- `npm run build-storybook`: ✅ pass(再現していたエラーが解消)
- `npm run lint`: ✅ pass(既存の無関係な warning 2 件のみ)
- `npm run format:check`: ✅ pass
- `npm run test:run`: ✅ 75/75 passed

## 影響範囲・リスク

- `tsconfig.json` の変更により、今後 `*.stories.tsx` が `tsc --noEmit` の対象に入る。型整合性が保たれるメリットがある一方、stories の型エラーは CI を落とすようになる。
- アプリ本体のロジックには変更なし(変更は stories と tsconfig のみ)。Chromatic 上の visual diff は出ない想定。